### PR TITLE
Hide {} in error message from formatting machinery

### DIFF
--- a/netidx-tools/src/recorder.rs
+++ b/netidx-tools/src/recorder.rs
@@ -147,7 +147,9 @@ mod publish {
             } else if s.as_str() == "tail" {
                 Ok(State::Tail)
             } else {
-                bail!("expected state {play, pause, tail}")
+                // Hide '{' in this error message from the formatting machinery in bail macro
+                let msg = "expected state {play, pause, tail}";
+                bail!(msg)
             }
         }
     }


### PR DESCRIPTION
I am considering supporting https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html in a future version of the bail macro, which would make e.g. `{play}` interpolate a variable called `play`, matching the standard library macros:

```rust
bail!("error {play}");  // equivalent to bail!("error {}", play)
```

I've been looking into how widely used `{` is in bail macro error messages. It looks like this is one of only very few places where it's used intentionally as a `{` character, as opposed to someone writing `{play}` in the message and expecting it to interpolate the value of `play` (not realizing it doesn't do that currently). If we can write this one a different way, I think it would be reasonable to provide the interpolating behavior from RFC 2795 in the future.