### PR TITLE
Fix decryption of bytes in krb5-encrypted channels

### DIFF
--- a/netidx/src/channel.rs
+++ b/netidx/src/channel.rs
@@ -415,10 +415,11 @@ fn read_task<C: K5Ctx + Debug + Send + Sync + 'static, S: AsyncRead + Send + 'st
                         None => break 'main Err(anyhow!("encryption is not supported")),
                     };
                     buf.advance(mem::size_of::<u32>());
-                    let decrypted = try_cf!(break, 'main, ctx.lock().unwrap(&buf[..len]));
-                    buf.advance(len);
-                    buf.extend_from_slice(&*decrypted);
-                    try_cf!(break, 'main, tx.send(mem::take(&mut buf)).await);
+                    let encrypted_chunk = buf.split_to(len);
+                    let decrypted = try_cf!(break, 'main, ctx.lock().unwrap(&*encrypted_chunk));
+                    let mut dec_buf = PBuf::default();
+                    dec_buf.extend_from_slice(&*decrypted);
+                    try_cf!(break, 'main, tx.send(dec_buf).await);
                 }
             }
             if buf.remaining_mut() < BUF {


### PR DESCRIPTION
As discovered by @alex-wayne-zj, there seems to be a bug in the `read_task()` function that will cause a netidx channel to fail to decrypt received krb5-encrypted bytes if there is more than one chunk of data in the buffer awaiting decryption.

As currently implemented, if `read_task()` encounters encrypted data, it decrypts the first available chunk of encrypted data, advances the buffer pointer, appends the decrypted data to the end of the buffer, and then sends the entire remaining buffer contents to the channel. That behavior is fine if there was only one chunk of encrypted data to be decrypted, but if there are additional encrypted chunks in the buffer, then what gets sent to the channel will be all the remaining encrypted chunks followed by the decrypted bytes of the one chunk that was decrypted.

This PR changes `read_task()` so that it creates a new `PBuf` for each chunk of decrypted data. This new `PBuf`' is then sent to the channel, leaving the original encrypted buffer unchanged.