### PR TITLE
Add optional `--per-client-buffer` to `netidx wsproxy`

### DIFF
--- a/netidx-wsproxy/src/config.rs
+++ b/netidx-wsproxy/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     #[serde(default)]
     #[structopt(
         long = "per-client-buffer",
-        help = "buffer updates per client so a slow client can't stall others (set a timeout)"
+        help = "buffer updates per client so a slow client can't stall others"
     )]
     pub per_client_buffer: bool,
 }

--- a/netidx-wsproxy/src/config.rs
+++ b/netidx-wsproxy/src/config.rs
@@ -12,4 +12,10 @@ pub struct Config {
     #[serde(default)]
     #[structopt(long = "key", help = "path to the private key")]
     pub key: Option<String>,
+    #[serde(default)]
+    #[structopt(
+        long = "per-client-buffer",
+        help = "buffer updates per client so a slow client can't stall others (set a timeout)"
+    )]
+    pub per_client_buffer: bool,
 }

--- a/netidx-wsproxy/src/lib.rs
+++ b/netidx-wsproxy/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::protocol::{Request, Response, Update};
 use ahash::AHashMap;
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use futures::{
     channel::mpsc,
     prelude::*,
@@ -45,6 +45,23 @@ struct PubEntry {
 
 type PendingCall =
     Pin<Box<dyn Future<Output = (u64, Result<Value>)> + Send + Sync + 'static>>;
+
+/// An outbound message queued for the per-client writer task (buffered mode).
+enum OutMsg {
+    Resp(Response),
+}
+
+/// Enqueue an outbound response for the writer task. Returns an error if the
+/// writer task has exited (e.g. the client hit its send timeout), which tells
+/// the control loop to shut this client down.
+fn send_buffered(
+    tx_out: &mpsc::UnboundedSender<OutMsg>,
+    resp: Response,
+) -> Result<()> {
+    tx_out
+        .unbounded_send(OutMsg::Resp(resp))
+        .map_err(|_| anyhow!("writer task gone"))
+}
 
 async fn reply<'a>(
     tx: &mut SplitSink<WebSocket, Message>,
@@ -269,6 +286,81 @@ impl ClientCtx {
         }
         Ok(batch.commit(timeout).await)
     }
+
+    // Buffered-mode counterpart of [process_from_client]. Instead of writing
+    // replies directly to the websocket sink (which can block the control loop
+    // on a slow client), every reply is enqueued on [tx_out] for the dedicated
+    // writer task. Reuses the same request-handling methods as the unbuffered
+    // path; only the reply delivery differs.
+    async fn process_from_client_buffered(
+        &mut self,
+        tx_out: &mpsc::UnboundedSender<OutMsg>,
+        queued: &mut Vec<result::Result<Message, warp::Error>>,
+        calls_pending: &mut FuturesUnordered<PendingCall>,
+        timeout: Option<Duration>,
+    ) -> Result<()> {
+        let mut batch = self.publisher.start_batch();
+        for r in queued.drain(..) {
+            let m = r?;
+            if m.is_ping() {
+                continue;
+            }
+            let resp = match m.to_str() {
+                Err(_) => Response::Error { error: "expected text".into() },
+                Ok(txt) => match serde_json::from_str::<Request>(txt) {
+                    Err(e) => Response::Error {
+                        error: format!("could not parse message {}", e),
+                    },
+                    Ok(req) => match req {
+                        Request::Subscribe { path } => {
+                            Response::Subscribed { id: self.subscribe(path) }
+                        }
+                        Request::Unsubscribe { id } => match self.unsubscribe(id) {
+                            Err(e) => Response::Error { error: e.to_string() },
+                            Ok(()) => Response::Unsubscribed,
+                        },
+                        Request::Write { id, val } => match self.write(id, val) {
+                            Err(e) => Response::Error { error: e.to_string() },
+                            Ok(()) => Response::Wrote,
+                        },
+                        Request::Publish { path, init } => {
+                            match self.publish(path, init) {
+                                Err(e) => Response::Error { error: e.to_string() },
+                                Ok(id) => Response::Published { id },
+                            }
+                        }
+                        Request::Unpublish { id } => match self.unpublish(id) {
+                            Err(e) => Response::Error { error: e.to_string() },
+                            Ok(()) => Response::Unpublished,
+                        },
+                        Request::Update { updates } => {
+                            match self.update(&mut batch, updates) {
+                                Err(e) => Response::Error { error: e.to_string() },
+                                Ok(()) => Response::Updated,
+                            }
+                        }
+                        Request::Call { id, path, args } => {
+                            match self.call(id, path, args) {
+                                Ok(pending) => {
+                                    calls_pending.push(pending);
+                                    continue;
+                                }
+                                Err(e) => Response::CallFailed {
+                                    id,
+                                    error: format!("rpc call failed {}", e),
+                                },
+                            }
+                        }
+                        Request::Unknown => {
+                            Response::Error { error: "unknown request".into() }
+                        }
+                    },
+                },
+            };
+            send_buffered(tx_out, resp)?;
+        }
+        Ok(batch.commit(timeout).await)
+    }
 }
 
 async fn handle_client(
@@ -318,6 +410,88 @@ async fn handle_client(
     }
 }
 
+// Per-client writer task used in buffered mode. It owns the websocket sink and
+// drains the unbounded outbound channel, applying the same per-message timeout
+// as [reply]. Because the control loop only ever feeds this task via a
+// non-blocking [mpsc::UnboundedSender::unbounded_send], a slow client backs up
+// here (in its own buffer) rather than stalling the control loop and, through
+// it, the shared subscriber connection. Returns Err on send timeout or socket
+// error, which signals the control loop to tear the client down.
+async fn writer_task(
+    mut tx: SplitSink<WebSocket, Message>,
+    mut rx_out: mpsc::UnboundedReceiver<OutMsg>,
+    timeout: Option<Duration>,
+) -> Result<()> {
+    while let Some(OutMsg::Resp(resp)) = rx_out.next().await {
+        reply(&mut tx, &resp, timeout).await?;
+    }
+    // The control loop dropped tx_out: flush and close the socket cleanly.
+    let _ = tx.close().await;
+    Ok(())
+}
+
+// Buffered counterpart of [handle_client]. Identical request handling, but all
+// websocket writes are offloaded to a dedicated [writer_task] via an unbounded
+// channel so the control loop never blocks on a slow client. This keeps the
+// bounded subscriber update channel (rx_up) drained promptly, so a slow client
+// can no longer stall update delivery to the other clients that share this
+// proxy's subscriber connection.
+async fn handle_client_buffered(
+    publisher: Publisher,
+    subscriber: Subscriber,
+    ws: WebSocket,
+    timeout: Option<Duration>,
+) -> Result<()> {
+    static UPDATES: LazyLock<Pool<Vec<Update>>> = LazyLock::new(|| Pool::new(50, 10000));
+    let (tx_up, mut rx_up) = mpsc::channel::<GPooled<Vec<(SubId, Event)>>>(3);
+    let mut ctx = ClientCtx::new(publisher, subscriber, tx_up);
+    let (tx_ws, rx_ws) = ws.split();
+    let (tx_out, rx_out) = mpsc::unbounded::<OutMsg>();
+    let mut writer = tokio::spawn(writer_task(tx_ws, rx_out, timeout));
+    let mut queued: Vec<result::Result<Message, warp::Error>> = Vec::new();
+    let mut rx_ws = Batched::new(rx_ws.fuse(), 10_000);
+    let mut calls_pending: FuturesUnordered<PendingCall> = FuturesUnordered::new();
+    calls_pending.push(Box::pin(async { future::pending().await }) as PendingCall);
+    loop {
+        select_biased! {
+            // If the writer task exits (client hit its send timeout, or the
+            // socket errored), tear down so the ClientCtx drop unsubscribes
+            // from the shared subscriber connection.
+            j = (&mut writer).fuse() => break match j {
+                Ok(r) => r,
+                Err(e) => Err(anyhow!("writer task failed: {}", e)),
+            },
+            (id, res) = calls_pending.select_next_some() => match res {
+                Ok(result) => {
+                    send_buffered(&tx_out, Response::CallSuccess { id, result })?
+                }
+                Err(e) => {
+                    let error = format!("rpc call failed {}", e);
+                    send_buffered(&tx_out, Response::CallFailed { id, error })?
+                }
+            },
+            r = rx_ws.select_next_some() => match r {
+                BatchItem::InBatch(r) => queued.push(r),
+                BatchItem::EndBatch => {
+                    ctx.process_from_client_buffered(
+                        &tx_out,
+                        &mut queued,
+                        &mut calls_pending,
+                        timeout
+                    ).await?
+                }
+            },
+            mut batch = rx_up.select_next_some() => {
+                let mut updates = UPDATES.take();
+                for (id, event) in batch.drain(..) {
+                    updates.push(Update {id, event});
+                }
+                send_buffered(&tx_out, Response::Update { updates })?
+            },
+        }
+    }
+}
+
 /// If you want to integrate the netidx api server into your own warp project
 /// this will return the filter path will be the http path where the websocket
 /// lives
@@ -327,6 +501,21 @@ pub fn filter(
     path: &'static str,
     timeout: Option<Duration>,
 ) -> BoxedFilter<(impl Reply,)> {
+    filter_opts(publisher, subscriber, path, timeout, false)
+}
+
+/// Like [filter], but with an explicit `per_client_buffer` option. When
+/// `per_client_buffer` is true each client gets a dedicated writer task fed by
+/// an unbounded buffer, so a single slow client cannot stall updates to the
+/// other clients sharing this proxy's subscriber. When false the behavior is
+/// identical to [filter].
+pub fn filter_opts(
+    publisher: Publisher,
+    subscriber: Subscriber,
+    path: &'static str,
+    timeout: Option<Duration>,
+    per_client_buffer: bool,
+) -> BoxedFilter<(impl Reply,)> {
     warp::path(path)
         .and(warp::ws())
         .map(move |ws: Ws| {
@@ -334,9 +523,12 @@ pub fn filter(
             ws.on_upgrade(move |ws| {
                 let (publisher, subscriber) = (publisher.clone(), subscriber.clone());
                 async move {
-                    if let Err(e) =
+                    let r = if per_client_buffer {
+                        handle_client_buffered(publisher, subscriber, ws, timeout).await
+                    } else {
                         handle_client(publisher, subscriber, ws, timeout).await
-                    {
+                    };
+                    if let Err(e) = r {
                         warn!("client handler exited: {}", e)
                     }
                 }
@@ -355,7 +547,8 @@ pub async fn run(
     subscriber: Subscriber,
     timeout: Option<Duration>,
 ) -> Result<()> {
-    let routes = filter(publisher, subscriber, "ws", timeout);
+    let routes =
+        filter_opts(publisher, subscriber, "ws", timeout, config.per_client_buffer);
     match (&config.cert, &config.key) {
         (_, None) | (None, _) => {
             warp::serve(routes).run(config.listen.parse::<SocketAddr>()?).await

--- a/netidx-wsproxy/tests/slow_client.rs
+++ b/netidx-wsproxy/tests/slow_client.rs
@@ -1,0 +1,266 @@
+//! End-to-end test that a single slow websocket client does not block update
+//! delivery to the other clients when `--per-client-buffer` is enabled.
+//!
+//! Topology (all in-process, loopback):
+//!   resolver server  <-  publisher (publishes /bench/data, updates rapidly)
+//!                    <-  wsproxy (shared Subscriber)  <-  two ws clients
+//!
+//! Client A reads continuously; client B subscribes then stops reading,
+//! simulating a slow consumer. We measure how many updates A receives in the
+//! final window, after buffers have had time to fill. With per-client buffering
+//! A keeps flowing; without it A stalls because B parks the shared subscriber
+//! connection (the bug this change fixes).
+//!
+//! The websocket client is hand-rolled over a raw TCP socket (a few dozen lines
+//! below) specifically so the test can stop reading and exert real TCP
+//! backpressure — which is the whole point of the slow-consumer scenario, and
+//! something the off-the-shelf test clients (e.g. warp::test::ws) cannot do
+//! because they drain the socket for you. It also avoids a new dependency.
+
+use netidx::{
+    config::Config as ClientConfig,
+    path::Path,
+    protocol::value::Value,
+    publisher::{BindCfg, Publisher, PublisherBuilder},
+    resolver_client::DesiredAuth,
+    resolver_server::{config::Config as ServerConfig, Server},
+    subscriber::Subscriber,
+};
+use std::{
+    io,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    task::JoinHandle,
+};
+
+const PATH: &str = "/bench/data";
+const PAYLOAD: usize = 64 * 1024;
+const SETTLE: Duration = Duration::from_secs(2);
+const TOTAL: Duration = Duration::from_secs(4);
+
+// Minimal websocket client over a raw TCP socket. Only implements what this
+// test needs: the client handshake, sending masked text frames, and reading
+// (unmasked) server frames. Crucially, it only reads when we ask it to, so a
+// client that stops calling `read_frame` exerts real TCP backpressure.
+struct RawWs {
+    stream: TcpStream,
+}
+
+impl RawWs {
+    async fn connect(addr: SocketAddr, path: &str) -> io::Result<Self> {
+        let mut stream = TcpStream::connect(addr).await?;
+        // "dGhlIHNhbXBsZSBub25jZQ==" is the canonical example 16-byte key; the
+        // server validates its presence and computes the accept hash. We don't
+        // verify the response beyond consuming the headers.
+        let req = format!(
+            "GET {path} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Connection: Upgrade\r\n\
+             Upgrade: websocket\r\n\
+             Sec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+        );
+        stream.write_all(req.as_bytes()).await?;
+        // Read up to (and including) the end of the response headers, one byte
+        // at a time so we never consume into the websocket frame stream.
+        let mut buf: Vec<u8> = Vec::with_capacity(256);
+        let mut byte = [0u8; 1];
+        loop {
+            stream.read_exact(&mut byte).await?;
+            buf.push(byte[0]);
+            if buf.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        Ok(Self { stream })
+    }
+
+    // Send a masked text frame (client frames must be masked per RFC 6455).
+    async fn send_text(&mut self, text: &str) -> io::Result<()> {
+        let payload = text.as_bytes();
+        let len = payload.len();
+        let mut frame = Vec::with_capacity(len + 14);
+        frame.push(0x81); // FIN + text opcode
+        if len < 126 {
+            frame.push(0x80 | len as u8);
+        } else if len <= 0xffff {
+            frame.push(0x80 | 126);
+            frame.extend_from_slice(&(len as u16).to_be_bytes());
+        } else {
+            frame.push(0x80 | 127);
+            frame.extend_from_slice(&(len as u64).to_be_bytes());
+        }
+        let mask = [0x12u8, 0x34, 0x56, 0x78];
+        frame.extend_from_slice(&mask);
+        for (i, b) in payload.iter().enumerate() {
+            frame.push(b ^ mask[i % 4]);
+        }
+        self.stream.write_all(&frame).await
+    }
+
+    // Read one server frame, returning (opcode, payload). Server frames are not
+    // masked. read_exact reassembles frames split across TCP segments.
+    async fn read_frame(&mut self) -> io::Result<(u8, Vec<u8>)> {
+        let mut hdr = [0u8; 2];
+        self.stream.read_exact(&mut hdr).await?;
+        let opcode = hdr[0] & 0x0f;
+        let masked = hdr[1] & 0x80 != 0;
+        let mut len = (hdr[1] & 0x7f) as usize;
+        if len == 126 {
+            let mut b = [0u8; 2];
+            self.stream.read_exact(&mut b).await?;
+            len = u16::from_be_bytes(b) as usize;
+        } else if len == 127 {
+            let mut b = [0u8; 8];
+            self.stream.read_exact(&mut b).await?;
+            len = u64::from_be_bytes(b) as usize;
+        }
+        let mut mask = [0u8; 4];
+        if masked {
+            self.stream.read_exact(&mut mask).await?;
+        }
+        let mut payload = vec![0u8; len];
+        self.stream.read_exact(&mut payload).await?;
+        if masked {
+            for (i, b) in payload.iter_mut().enumerate() {
+                *b ^= mask[i % 4];
+            }
+        }
+        Ok((opcode, payload))
+    }
+
+    // Subscribe to PATH and block until the subscription is confirmed.
+    async fn subscribe(&mut self) -> io::Result<()> {
+        self.send_text(&format!(r#"{{"type":"Subscribe","path":"{PATH}"}}"#)).await?;
+        loop {
+            let (opcode, payload) = self.read_frame().await?;
+            if opcode == 0x1
+                && String::from_utf8_lossy(&payload).contains(r#""type":"Subscribed""#)
+            {
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn start_backend() -> (Server, Publisher, Subscriber) {
+    let server_cfg =
+        ServerConfig::load("../cfg/simple-server.json").expect("load server cfg");
+    let mut client_cfg =
+        ClientConfig::load("../cfg/simple-client.json").expect("load client cfg");
+    let server = Server::new(server_cfg, false, 0).await.expect("start resolver");
+    client_cfg.addrs[0].0 = *server.local_addr();
+    let publisher = PublisherBuilder::new(client_cfg.clone())
+        .desired_auth(DesiredAuth::Anonymous)
+        .bind_cfg(Some(BindCfg::Local))
+        .build()
+        .await
+        .expect("build publisher");
+    let subscriber =
+        Subscriber::new(client_cfg, DesiredAuth::Anonymous).expect("build subscriber");
+    (server, publisher, subscriber)
+}
+
+// Publish PATH and spawn a task that updates it rapidly with a large payload
+// (large so a non-reading client's socket buffers fill quickly).
+fn start_publishing(publisher: &Publisher) -> JoinHandle<()> {
+    let val = publisher
+        .publish(Path::from(PATH), Value::from("init".to_string()))
+        .expect("publish");
+    let publisher = publisher.clone();
+    tokio::spawn(async move {
+        let filler = "x".repeat(PAYLOAD);
+        let mut n: u64 = 0u64;
+        loop {
+            n += 1;
+            let mut batch = publisher.start_batch();
+            val.update(&mut batch, Value::from(format!("{n}-{filler}")));
+            // None timeout: never forcibly disconnect a slow subscriber, so we
+            // observe the steady-state head-of-line behavior.
+            batch.commit(None).await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+}
+
+// Run one scenario; returns the number of Update messages client A receives in
+// the final (TOTAL - SETTLE) window while client B is a stalled consumer.
+async fn run_scenario(per_client_buffer: bool) -> u64 {
+    let (server, publisher, subscriber) = start_backend().await;
+    let updater = start_publishing(&publisher);
+
+    let routes = netidx_wsproxy::filter_opts(
+        publisher.clone(),
+        subscriber.clone(),
+        "ws",
+        None,
+        per_client_buffer,
+    );
+    let (addr, srv) = warp::serve(routes).bind_ephemeral(([127, 0, 0, 1], 0u16));
+    let proxy = tokio::spawn(srv);
+
+    let mut a = RawWs::connect(addr, "/ws").await.expect("connect A");
+    let mut b = RawWs::connect(addr, "/ws").await.expect("connect B");
+    a.subscribe().await.expect("subscribe A");
+    b.subscribe().await.expect("subscribe B");
+
+    // From here on, B never reads again: it is the slow consumer.
+    let start = Instant::now();
+    let mut count = 0u64;
+    loop {
+        let elapsed = start.elapsed();
+        if elapsed >= TOTAL {
+            break;
+        }
+        match tokio::time::timeout(TOTAL - elapsed, a.read_frame()).await {
+            Ok(Ok((0x1, payload))) => {
+                if start.elapsed() >= SETTLE
+                    && String::from_utf8_lossy(&payload).contains(r#""type":"Update""#)
+                {
+                    count += 1;
+                }
+            }
+            Ok(Ok((0x8, _))) => break, // server closed
+            Ok(Ok(_)) => (),          // other control/data frame
+            Ok(Err(e)) => panic!("client A read error: {e}"),
+            Err(_) => break, // measurement window elapsed
+        }
+    }
+
+    drop(b);
+    updater.abort();
+    proxy.abort();
+    drop(server);
+    count
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_client_does_not_block_others() {
+    // The fix: with per-client buffering, A keeps receiving updates even though
+    // B has stopped reading.
+    let fixed = run_scenario(true).await;
+    // The bug: without it, B's stall parks the shared subscriber connection and
+    // A stops receiving updates.
+    let buggy = run_scenario(false).await;
+
+    eprintln!(
+        "updates received by fast client A in final {}s window: \
+         per-client-buffer ON = {fixed}, OFF = {buggy}",
+        (TOTAL - SETTLE).as_secs(),
+    );
+
+    assert!(
+        fixed >= 50,
+        "with per-client-buffer ON, the fast client should keep receiving \
+         updates despite a slow peer, but only got {fixed}"
+    );
+    assert!(
+        buggy * 5 < fixed,
+        "expected the fast client to be starved with per-client-buffer OFF \
+         (got {buggy}) relative to ON (got {fixed}); the slow peer should stall it"
+    );
+}


### PR DESCRIPTION
This PR addresses the issue first reported in https://github.com/netidx/netidx/issues/11.

It duplicates the existing `process_from_client()` and `handle_client()` functions in the `netidx-wsproxy` crate, adding counterpart functions that allocate a buffer for each websocket client so that a single slow client won't block updates to other clients. Use of the new functions is gated behind an optional `--per-client-buffer` argument to the `netidx wsproxy` command.  Without the optional `--per-client-buffer` argument, the behavior of netidx wsproxy remains completely unchanged.